### PR TITLE
Inject firebase config and API keys into app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ Thumbs.db
 .runtimeconfig.json
 
 .terraform/
-env.json

--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -16,7 +16,8 @@
     GOOGLE_PROJECT = "<project-id>";
     CLOUDSDK_CORE_PROJECT = "<project-id>";
     TF_VAR_project = "<project-id>";
-    NG_CLI_ANALYTICS="false";
+    # Flip to true to help improve Angular
+    NG_CLI_ANALYTICS = "false";
   };
 
   idx = {

--- a/src/environments/environments.ts.tmpl
+++ b/src/environments/environments.ts.tmpl
@@ -1,0 +1,13 @@
+export const environment = {
+  firebase: {
+      apiKey: '${api_key}',
+      authDomain: '${auth_domain}',
+      databaseURL: '${database_url}',
+      projectId: '${project_id}',
+      storageBucket: '${storage_bucket}',
+      messagingSenderId: '${messaging_sender_id}',
+      appId: '${web_app_id}',
+      measurementId: '${measurement_id}',
+  },
+  gemini_api: '${gemini_api_key}'
+};


### PR DESCRIPTION
The IDX initialization is fully functional now. Next I'll just be adding helpful comments all around.

During IDX initialization, the following happens

1. Terraform executes main.tf to provision resources such as API key, web app, quota limits
2. Terraform outputs the result based on the `environments.ts.tmpl` template. Thus, the config is project specific.
3. `ng serve` picks up this template and compiles it into the app